### PR TITLE
Fix camera mic - TOO DAMN LOW!

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -2351,11 +2351,11 @@
     </path>
 
     <path name="camcorder-stereo-dmic">
-        <path name="line-landscapecam" />
+        <path name="handset-mic" />
     </path>
 
     <path name="camcorder-stereo-dmic-reverse">
-        <path name="line-invertlandscapecam" />
+        <path name="handset-mic" />
     </path>
 
     <path name="hdmi-tx">


### PR DESCRIPTION
Audio mixer paths are set by default to use stereo mic - but this isn't working right for some reason.

This just sets camcorder mic to use the mono/default mic.
